### PR TITLE
Update ktx-completion.sh to only return files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ install ktx "${HOME}"/bin
 cp ktx-completion.sh "${HOME}"/.ktx-completion.sh
 
 # Add this to your "${HOME}/".bash_profile (or similar)
-source "${HOME}"/.ktx-completion.sh'
+source "${HOME}"/.ktx-completion.sh
 
 # Reload your shell
 exec bash

--- a/ktx-completion.sh
+++ b/ktx-completion.sh
@@ -17,6 +17,6 @@
 KUBECONFIG_DIR=${KUBECONFIG_DIR:-"${HOME}/.kube/"}
 _ktx() {
        local cur=${COMP_WORDS[COMP_CWORD]}
-       COMPREPLY=( $(compgen -W "$(ls ${KUBECONFIG_DIR})" -- $cur) )
+       COMPREPLY=( $(compgen -W "$(find ${KUBECONFIG_DIR} -maxdepth 1 -type f -exec basename {} \;)" -- $cur) )
 }
 complete -F _ktx ktx

--- a/ktx-completion.sh
+++ b/ktx-completion.sh
@@ -14,9 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 KUBECONFIG_DIR=${KUBECONFIG_DIR:-"${HOME}/.kube/"}
+
+_getconf()
+{
+	find ${KUBECONFIG_DIR} -maxdepth 1 -type f -exec basename {} \;
+}
+
 _ktx() {
        local cur=${COMP_WORDS[COMP_CWORD]}
-       COMPREPLY=( $(compgen -W "$(find ${KUBECONFIG_DIR} -maxdepth 1 -type f -exec basename {} \;)" -- $cur) )
+       COMPREPLY=( $(compgen -W "$(_getconf)" -- $cur) )
 }
 complete -F _ktx ktx

--- a/ktx-completion.sh
+++ b/ktx-completion.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 KUBECONFIG_DIR=${KUBECONFIG_DIR:-"${HOME}/.kube/"}
 
 _getconf()


### PR DESCRIPTION
ktx-completion returns everything underneath the .kube directory, including directories. This change will now only return files that are directly underneath the .kube directory.