### PR TITLE
ktx: Verify the existence of config file before sourcing

### DIFF
--- a/ktx
+++ b/ktx
@@ -15,7 +15,12 @@
 # limitations under the License.
 
 main() {
-    # TODO: ensure the file actually exists.
-    echo "export KUBECONFIG=\"${HOME}/.kube/${1}\""
+    if [ -e "${HOME}/.kube/${1}" ];then
+        echo "export KUBECONFIG=\"${HOME}/.kube/${1}\""
+    else
+    # We need to echo out an additional echo command so that when ktx is run through eval
+    # the output is in the appropriate format to be sent to the console.
+        echo "echo \"The following file does not exist: ${HOME}/.kube/${1}. Exiting...\""
+    fi
 }
 main ${1}


### PR DESCRIPTION
Check for the existence of the config file before exporting the KUBECONFIG environment variable

Signed-off-by: Tyler Auerbeck <auerbecktj@gmail.com>

Fixes #2