### PR TITLE
Convert ktx to a bash function to eval automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Managing kubeconfig files can become tedious when you have multiple clusters and
 ### Prerequisites
 
 * Your shell is bash.
-* `${HOME}/bin` exists and is in your `${PATH}`.
 * `git` is installed.
 
 ### Install
@@ -21,8 +20,11 @@ Managing kubeconfig files can become tedious when you have multiple clusters and
 git clone https://github.com/heptio/ktx
 cd ktx
 
-# Install the script
-install ktx "${HOME}"/bin
+# Install the bash function
+cp ktx "${HOME}"/.ktx
+
+# Add this to your "${HOME}/".bash_profile (or similar)
+source "${HOME}"/.ktx
 
 # Install the auto-completion
 cp ktx-completion.sh "${HOME}"/.ktx-completion.sh
@@ -45,9 +47,6 @@ The connection to the server localhost:8080 was refused - did you specify the ri
 $ ktx <tab><tab>
 alpha beta gamma delta epsilon
 $ ktx gamma
-export KUBECONFIG=/home/you/.kube/gamma
-# Set the environment variable
-$ eval $(ktx gamma)
 $ kubectl get po
 No resources found.
 ```

--- a/ktx
+++ b/ktx
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-main() {
+ktx() {
     # Test that we have a $HOME/.kube to work with
     if [ ! -d "${HOME}/.kube" ]; then
         echo "echo \"The following directory does not exist: ${HOME}/.kube. Exiting...\""
@@ -27,12 +27,17 @@ main() {
         exit 1
     fi
 
+    # If no argument was given then list the files in $HOME/.kube
+    if [ -z "$1" ]; then
+      find "${HOME}/.kube" -maxdepth 1 -type f -exec basename {} \;
+      return;
+    fi
+
     # Verify config exists
     if [ -e "${HOME}/.kube/${1}" ]; then
-        echo "export KUBECONFIG=\"${HOME}/.kube/${1}\""
+        eval "export KUBECONFIG=\"${HOME}/.kube/${1}\""
     else
         echo "echo \"The following file does not exist: ${HOME}/.kube/${1}. Exiting...\""
         exit 1
     fi
 }
-main ${1}


### PR DESCRIPTION
This changes `ktx` to run as a bash function so that you can eval the `KUBECONFIG` environment variable automatically. Additionally, if you run the function with no args it will list all of the configs in your `$HOME/.kube` directory.