### PR TITLE
Dropping eval and just using export

### DIFF
--- a/ktx
+++ b/ktx
@@ -35,7 +35,7 @@ ktx() {
 
     # Verify config exists
     if [ -e "${HOME}/.kube/${1}" ]; then
-        eval "export KUBECONFIG=\"${HOME}/.kube/${1}\""
+        export KUBECONFIG="${HOME}/.kube/${1}"
     else
         echo "echo \"The following file does not exist: ${HOME}/.kube/${1}. Exiting...\""
         exit 1


### PR DESCRIPTION
Now that we're using a bash function the eval isn't necessary at all.