### PR TITLE
Fix old GitHub url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Managing kubeconfig files can become tedious when you have multiple clusters and
 ### Install
 
 ```sh
-# clone the ktx repo
-git clone https://github.com/heptio/ktx
+# Clone the ktx repo
+git clone https://github.com/heptiolabs/ktx
 cd ktx
 
 # Install the bash function


### PR DESCRIPTION
Although GitHub redirects the old url to the new one, it is better for long term maintainability to update it.

Signed-off-by: Gregor Krmelj <gregor@krmelj.xyz>