### PR TITLE
Add fzf feature, add none autocomplete/output

### DIFF
--- a/ktx
+++ b/ktx
@@ -29,12 +29,28 @@ ktx() {
 
     # If no argument was given then list the files in $HOME/.kube
     if [ -z "$1" ]; then
+      ch="none\n"
       for kube in $(find "${HOME}/.kube" -maxdepth 1 -type f -o -type l); do
         if [[ "${KUBECONFIG}" == "$kube" ]]; then
-          echo -n "(active) "
+          ch="$ch(active) "
         fi
-        echo $(basename "${kube}")
+        ch=${ch}$(basename "${kube}")"\n"
       done
+
+      # if fzf is installed, use it to choose the context
+      if type fzf &>/dev/null ; then
+        choice=$(echo $ch | fzf)
+      else
+        echo -n $ch
+        return
+      fi
+      if [ ! -z "$choice" ] ; then
+        if [[ "$choice" == "none" ]] || [[ "$choice" == "None" ]]; then
+          unset KUBECONFIG
+          return
+        fi
+        export KUBECONFIG="${HOME}/.kube/${choice}"
+      fi
 
       return
     fi

--- a/ktx
+++ b/ktx
@@ -29,19 +29,19 @@ ktx() {
 
     # If no argument was given then list the files in $HOME/.kube
     if [ -z "$1" ]; then
-      ch="none\n"
+      opts="none\n"
       for kube in $(find "${HOME}/.kube" -maxdepth 1 -type f -o -type l); do
         if [[ "${KUBECONFIG}" == "$kube" ]]; then
-          ch="$ch(active) "
+          opts="$opts(active) "
         fi
-        ch=${ch}$(basename "${kube}")"\n"
+        opts=${opts}$(basename "${kube}")"\n"
       done
 
       # if fzf is installed, use it to choose the context
       if type fzf &>/dev/null ; then
-        choice=$(echo $ch | fzf)
+        choice=$(echo $opts | fzf)
       else
-        echo -n $ch
+        echo -n $opts
         return
       fi
       if [ ! -z "$choice" ] ; then

--- a/ktx-completion.sh
+++ b/ktx-completion.sh
@@ -19,6 +19,7 @@ KUBECONFIG_DIR=${KUBECONFIG_DIR:-"${HOME}/.kube/"}
 _getconf()
 {
        find ${KUBECONFIG_DIR} -maxdepth 1 \( -type f -o -type l \) -exec basename {} \;
+       echo "none"
 }
 
 _ktx() {


### PR DESCRIPTION
This adds a nice way to use fzf (interactive ktx selection) if it's installed,
and adds 'none' as an option to reflect its availability to the user despite not
being a `.kube/` file.
